### PR TITLE
Add --max-depth and --include options

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ Options:
 
   -h, --help                  output usage information
   -V, --version               output the version number
-  -e, --extensions <list>     The extensions to take into account; defaults to .htm,.html
-  -E, --exclude <regexp>      Exclude files and directories that are matched by this regular expression
+  -e, --extensions <list>     The extensions to take into account (defaults to .htm,.html)
+  -I, --include <regexp>      Include files and directories that are matched by this regular expression (defaults to all)
+  -E, --exclude <regexp>      Exclude files and directories that are matched by this regular expression (defaults to none)
   -H, --html                  Enable to generate HTML output
   -L, --no-link-folders       Do not link folders when in HTML output mode
   -F, --no-empty-directories  Do not include empty directories
+  -D, --max-depth             Limit results to a maximum sub-directory depth
 ```
 
 #### Install
@@ -71,10 +73,13 @@ indexifier --extensions .html --html .
 
 ```
 indexifier(String directory [, opts={
-                                     fileTypes: Array.<String>
+                                     fileTypes: Array.<String>,
+                                     include=undefined: Regexp,
+                                     exclude=undefined: Regexp,
                                      isHtml=false: Boolean,
-                                     linkFolders=true: Boolean
-                                     emptyFolders=true: Boolean
+                                     linkFolders=true: Boolean,
+                                     emptyFolders=true: Boolean,
+                                     maxDepth=Infinity: Number,
                                     }]);
 ```
 

--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -87,6 +87,8 @@ exports[`indexifier should be able to transform a directory structure limited to
 ├── 1
 ├── 2
 └── 3
+"
+`;
 
 exports[`indexifier should be able to transform a directory structure with filtering by extensions 1`] = `
 "1

--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -90,3 +90,11 @@ exports[`indexifier should be able to transform a directory structure html w/o l
 </html>
 "
 `;
+
+exports[`indexifier should be able to transform a directory structure limited to maxDepth of 1 1`] = `
+"fixtures
+├── 1
+├── 2
+└── 3
+"
+`;

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -17,6 +17,11 @@ describe('indexifier', () => {
             expect(ret).toMatchSnapshot();
         });
 
+        it('limited to maxDepth of 1', () => {
+            const ret = indexifier(fixturesDir, { maxDepth: 1 });
+            expect(ret).toMatchSnapshot();
+        });
+
         describe('html', () => {
             it('to HTML', () => {
                 const ret = indexifier(dir, { isHtml: true });

--- a/bin/index.js
+++ b/bin/index.js
@@ -16,6 +16,7 @@ program
   .option('-L, --no-link-folders', 'Do not link folders when in HTML output mode')
   .option('-F, --no-empty-directories', 'Do not include empty directories')
   .option('-E, --exclude <regexp>', 'Exclude files and directories that are matched by this regular expression')
+  .option('-D, --max-depth <number>', 'Limit results to a maximum sub-directory depth')
   .action((dir) => {
     try {
       console.log(indexifier(dir, {
@@ -23,6 +24,7 @@ program
           fileTypes: program.extensions,
           isHtml: program.html,
           linkFolders: program.linkFolders,
+          maxDepth: program.maxDepth,
       }));
     } catch(e) {
       console.error(e.message);

--- a/dirTreeFilters.js
+++ b/dirTreeFilters.js
@@ -1,0 +1,60 @@
+/**
+ * Remove all tree nodes below a given depth.
+ * Note: This feature can be inefficient due to this filtering taking place on a complete directory tree,
+ * compared to filtering while building the dirTree in the first place.
+ * To fix we would need to add this feature to directory-tree instead.
+ * @param {dirTree} tree A directory tree
+ * @param {number} maxDepth Maximum depth of files/directories to include in tree
+ */
+function filterToMaxDepth(tree, maxDepth) {
+  if (tree.children && tree.children.length > 0) {
+      if (maxDepth <= 0) {
+          tree.children = []
+      } else {
+          tree.children.forEach(child => {
+              if (child.type === 'directory') {
+                  filterToMaxDepth(child, maxDepth - 1);
+              }
+          })
+      }
+  }
+}
+
+/**
+* Remove files and directories from tree that don't match regexp.
+* Note: This feature can be inefficient due to this filtering taking place on a complete directory tree,
+* compared to filtering while building the dirTree in the first place.
+* To fix we would need to add this feature to directory-tree instead.
+* @param {dirTree} tree A directory tree
+* @param {Regexp} regexp Regexp to match nodes against
+*/
+function filterIncluded(tree, regexp) {
+  if (!tree || !regexp.test(tree.name)) {
+      return false;
+  }
+  if (tree.children && tree.children.length > 0) {
+      tree.children = tree.children.filter(child => filterIncluded(child, regexp));
+  }
+  return true;
+}
+
+/**
+ * Remove empty directories from the given tree
+ * @param {dirTree} tree A directory tree
+ */
+function filterEmptyDirectories(tree) {
+  if (tree.children && tree.children.length > 0) {
+      tree.children.forEach(child => {
+          if (child.type === 'directory') {
+              child.children = filterEmptyDirectories(child);
+          }
+      });
+  }
+  return tree.children = tree.children.filter(child => child.type === 'file' || child.children.length > 0);
+}
+
+module.exports = {
+  filterToMaxDepth,
+  filterIncluded,
+  filterEmptyDirectories,
+}

--- a/dirTreeFilters.js
+++ b/dirTreeFilters.js
@@ -9,7 +9,7 @@
 function filterToMaxDepth(tree, maxDepth) {
   if (tree.children && tree.children.length > 0) {
       if (maxDepth <= 0) {
-          tree.children = []
+          tree.children = [];
       } else {
           tree.children.forEach(child => {
               if (child.type === 'directory') {

--- a/index.js
+++ b/index.js
@@ -13,7 +13,12 @@ const defaultOpts = {
     linkFolders: true,
     exclude: undefined,
     emptyDirectories: true,
+    maxDepth: Infinity,
 };
+
+function filterToMaxDepth(tree, maxDepth) {
+    
+}
 
 function filterEmptyDirectories(tree) {
     if (tree.children && tree.children.length > 0) {
@@ -46,7 +51,7 @@ module.exports = (dir, opts) => {
     if (!stats.isDirectory()) {
         throw new DirectoryInvalidError(`Given directory "${dir}" is not valid`);
     }
-    const { exclude, fileTypes, isHtml, linkFolders, emptyDirectories } = Object.assign({}, defaultOpts, opts);
+    const { exclude, fileTypes, isHtml, linkFolders, emptyDirectories, maxDepth } = Object.assign({}, defaultOpts, opts);
 
     let tree = dirTree(dir, {
         exclude: exclude
@@ -57,6 +62,9 @@ module.exports = (dir, opts) => {
             : undefined,
     });
 
+    if (maxDepth !== Infinity) {
+        filterToMaxDepth(tree, maxDepth);
+    }
     if (!emptyDirectories) {
         filterEmptyDirectories(tree);
     }

--- a/index.js
+++ b/index.js
@@ -19,8 +19,11 @@ const defaultOpts = {
 
 /**
  * Remove all tree nodes below a given depth.
- * @param {*} tree 
- * @param {*} maxDepth 
+ * Note: This feature can be inefficient due to this filtering taking place on a complete directory tree,
+ * compared to filtering while building the dirTree in the first place.
+ * To fix we would need to add this feature to directory-tree instead.
+ * @param {dirTree} tree A directory tree
+ * @param {number} maxDepth Maximum depth of files/directories to include in tree
  */
 function filterToMaxDepth(tree, maxDepth) {
     if (tree.children && tree.children.length > 0) {
@@ -37,9 +40,12 @@ function filterToMaxDepth(tree, maxDepth) {
 }
 
 /**
- * Remove files and directories from tree that don't match regexp
- * @param {dirTree} tree 
- * @param {Regexp} regexp
+ * Remove files and directories from tree that don't match regexp.
+ * Note: This feature can be inefficient due to this filtering taking place on a complete directory tree,
+ * compared to filtering while building the dirTree in the first place.
+ * To fix we would need to add this feature to directory-tree instead.
+ * @param {dirTree} tree A directory tree
+ * @param {Regexp} regexp Regexp to match nodes against
  */
 function filterIncluded(tree, regexp) {
     if (!tree || !regexp.test(tree.name)) {

--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ function filterEmptyDirectories(tree) {
 *                        {Array.<String>} fileTypes The file types to print. Defaults to all file types.
 *                        {RegExp|undefined} exclude A regular expression matching files/directories to exclude.
 *                        {Boolean} isHtml Whether to produce HTML output. Defaults to false.
+*                        {Number} maxDepth Limit results to a maximum sub-directory depth. Defaults to Infinity.
 * @return {String} A unicode string containing a directory tree
 */
 module.exports = (dir, opts) => {

--- a/index.js
+++ b/index.js
@@ -49,7 +49,9 @@ function filterEmptyDirectories(tree) {
 *                        {Array.<String>} fileTypes The file types to print. Defaults to all file types.
 *                        {RegExp|undefined} exclude A regular expression matching files/directories to exclude.
 *                        {Boolean} isHtml Whether to produce HTML output. Defaults to false.
-*                        {Number} maxDepth Limit results to a maximum sub-directory depth. Defaults to Infinity.
+*                        {Boolean} linkFolders Link folders when in HTML output mode. Defaults to true.
+*                        {Boolean} emptyDirectories Include empty directories. Defaults to true.
+*                        {Number} maxDepth Limit results to a maximum sub-directory depth. Defaults to no limit.
 * @return {String} A unicode string containing a directory tree
 */
 module.exports = (dir, opts) => {

--- a/index.js
+++ b/index.js
@@ -17,6 +17,11 @@ const defaultOpts = {
     maxDepth: Infinity,
 };
 
+/**
+ * Remove all tree nodes below a given depth.
+ * @param {*} tree 
+ * @param {*} maxDepth 
+ */
 function filterToMaxDepth(tree, maxDepth) {
     if (tree.children && tree.children.length > 0) {
         if (maxDepth <= 0) {
@@ -39,7 +44,6 @@ function filterToMaxDepth(tree, maxDepth) {
 function filterIncluded(tree, regexp) {
     if (!tree || !regexp.test(tree.name)) {
         return false;
-    } else {
     }
     if (tree.children && tree.children.length > 0) {
         tree.children = tree.children.filter(child => filterIncluded(child, regexp));

--- a/index.js
+++ b/index.js
@@ -17,7 +17,17 @@ const defaultOpts = {
 };
 
 function filterToMaxDepth(tree, maxDepth) {
-    
+    if (tree.children && tree.children.length > 0) {
+        if (maxDepth <= 0) {
+            tree.children = []
+        } else {
+            tree.children.forEach(child => {
+                if (child.type === 'directory') {
+                    filterToMaxDepth(child, maxDepth - 1);
+                }
+            })
+        }
+    }
 }
 
 function filterEmptyDirectories(tree) {

--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ const dirTreeToArchyTree = require('./dirTreeToArchyTree');
 const wrapHtml = require('./wrapHtml');
 const { DirectoryInvalidError } = require('./exceptions');
 
+const { filterToMaxDepth, filterIncluded, filterEmptyDirectories } = require('./dirTreeFilters')
+
 const defaultOpts = {
     fileTypes: null,
     isHtml: false,
@@ -18,59 +20,7 @@ const defaultOpts = {
 };
 
 /**
- * Remove all tree nodes below a given depth.
- * Note: This feature can be inefficient due to this filtering taking place on a complete directory tree,
- * compared to filtering while building the dirTree in the first place.
- * To fix we would need to add this feature to directory-tree instead.
- * @param {dirTree} tree A directory tree
- * @param {number} maxDepth Maximum depth of files/directories to include in tree
- */
-function filterToMaxDepth(tree, maxDepth) {
-    if (tree.children && tree.children.length > 0) {
-        if (maxDepth <= 0) {
-            tree.children = []
-        } else {
-            tree.children.forEach(child => {
-                if (child.type === 'directory') {
-                    filterToMaxDepth(child, maxDepth - 1);
-                }
-            })
-        }
-    }
-}
-
-/**
- * Remove files and directories from tree that don't match regexp.
- * Note: This feature can be inefficient due to this filtering taking place on a complete directory tree,
- * compared to filtering while building the dirTree in the first place.
- * To fix we would need to add this feature to directory-tree instead.
- * @param {dirTree} tree A directory tree
- * @param {Regexp} regexp Regexp to match nodes against
- */
-function filterIncluded(tree, regexp) {
-    if (!tree || !regexp.test(tree.name)) {
-        return false;
-    }
-    if (tree.children && tree.children.length > 0) {
-        tree.children = tree.children.filter(child => filterIncluded(child, regexp));
-    }
-    return true;
-}
-
-function filterEmptyDirectories(tree) {
-    if (tree.children && tree.children.length > 0) {
-        tree.children.forEach(child => {
-            if (child.type === 'directory') {
-                child.children = filterEmptyDirectories(child);
-            }
-        });
-    }
-    return tree.children = tree.children.filter(child => child.type === 'file' || child.children.length > 0);
-}
-
-/**
 * Generates a directory tree from the given directory and all sub-directories
-*
 * @param {!String} dir The directory to use as the start (this will be the root node of the tree)
 * @param {Object} [opts] An object which supports the following options:
 *                        {Array.<String>} fileTypes The file types to print. Defaults to all file types.

--- a/index.js
+++ b/index.js
@@ -3,11 +3,10 @@ const fs = require('fs');
 const dirTree = require('directory-tree');
 const archy = require('archy');
 
+const { filterToMaxDepth, filterIncluded, filterEmptyDirectories } = require('./dirTreeFilters')
 const dirTreeToArchyTree = require('./dirTreeToArchyTree');
 const wrapHtml = require('./wrapHtml');
 const { DirectoryInvalidError } = require('./exceptions');
-
-const { filterToMaxDepth, filterIncluded, filterEmptyDirectories } = require('./dirTreeFilters')
 
 const defaultOpts = {
     fileTypes: null,


### PR DESCRIPTION
### In this PR
- Added the `-D, --max-depth <number>` option to limit the generated directory tree to a given depth.
- Added the `-I, --include <regexp>` option to only include matching files and directories in the directory tree.
- Fixed up some function comments that were left out of date prior to these changes.

### Background
Both options are useful features to have. `--include` can work alongside the existing `--extensions` option.

### Details
Unfortunately both features only filter after the directory tree has already been generated. This means they are not as efficient as they could be (a speed difference should only be noticeable on very large directories, but this is untested). To fix this, the features need to be implemented in the [`directory-tree`](https://www.npmjs.com/package/directory-tree) package instead.