### PR TITLE
Use the --no-empty-directories CLI arg

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -23,6 +23,7 @@ program
       console.log(indexifier(dir, {
           include: program.include,
           exclude: program.exclude,
+          emptyDirectories: program.emptyDirectories,
           fileTypes: program.extensions,
           isHtml: program.html,
           linkFolders: program.linkFolders,


### PR DESCRIPTION
The CLI never actually passed along the user input value of `--no-empty-directories`, it just always defaulted to `true`.